### PR TITLE
Remove Book PR

### DIFF
--- a/client/src/utils/mutations.js
+++ b/client/src/utils/mutations.js
@@ -43,7 +43,7 @@ export const SAVE_BOOK = gql`
 `;
 
 export const REMOVE_BOOK = gql`
-  mutation removeBook($bookId: ID!) {
+  mutation removeBook($bookId: String!) {
     removeBook(bookId: $bookId) {
       _id
       username


### PR DESCRIPTION
This commit fixes the inconsistency with the removeBook mutation. type ID was being called instead of string in the mutations.js file.